### PR TITLE
Add barebones NixOS configuration with Docker and docker-compose

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -1,0 +1,28 @@
+{ config, pkgs, ... }:
+
+{
+  # Update this to match your system's hardware profile if needed.
+  # imports = [ ./hardware-configuration.nix ];
+
+  boot.loader.systemd-boot.enable = true;
+  boot.loader.efi.canTouchEfiVariables = true;
+
+  networking.hostName = "nixos";
+  networking.networkmanager.enable = true;
+
+  time.timeZone = "UTC";
+
+  users.users.admin = {
+    isNormalUser = true;
+    extraGroups = [ "wheel" "docker" ];
+  };
+
+  services.openssh.enable = true;
+
+  virtualisation.docker.enable = true;
+  environment.systemPackages = [
+    pkgs.docker-compose
+  ];
+
+  system.stateVersion = "24.05";
+}


### PR DESCRIPTION
### Motivation
- Provide a minimal `configuration.nix` for a NixOS server that boots with `systemd-boot` and includes Docker tooling for running containers.

### Description
- Add a simple `configuration.nix` that enables `virtualisation.docker`, adds `pkgs.docker-compose` to `environment.systemPackages`, configures a basic `admin` user in `wheel` and `docker` groups, enables `services.openssh` and `networking.networkmanager`, and sets `system.stateVersion`.

### Testing
- No automated tests were run; this is a static configuration file intended for manual deployment and verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983b070cd588324b02e5add8032b907)